### PR TITLE
🔧 (backend-local.yml): set docker compose restart policy to 'no'

### DIFF
--- a/backend-local.yml
+++ b/backend-local.yml
@@ -1,7 +1,7 @@
 services:
   walrus-db:
     image: postgres:14
-    restart: on-failure
+    restart: no
     env_file:
       - ./env/walrus-local.env
     volumes:
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
 
   walrus-redis:
-    restart: on-failure
+    restart: no
     image: redis:7.4.2
     env_file:
       - ./env/walrus-local.env
@@ -29,7 +29,7 @@ services:
       - walrus-db
       - walrus-redis
       - walrus-rabbitmq
-    restart: on-failure
+    restart: no
     env_file:
       - ./env/walrus-local.env
     working_dir: /usr/src/app
@@ -46,7 +46,7 @@ services:
 
   walrus-rabbitmq:
     image: rabbitmq:3-management
-    restart: on-failure
+    restart: no
     env_file:
       - ./env/walrus-local.env
     ports:
@@ -63,7 +63,7 @@ services:
       - walrus-db
       - walrus-redis
       - walrus-rabbitmq
-    restart: on-failure
+    restart: no
     env_file:
       - ./env/walrus-local.env
     working_dir: /usr/src/app
@@ -85,7 +85,7 @@ services:
   #     - walrus-db
   #     - walrus-redis
   #     - walrus-rabbitmq
-  #   restart: on-failure
+  #   restart: no
   #   env_file:
   #     - ./env/walrus-local.env
   #   working_dir: /usr/src/app
@@ -103,7 +103,7 @@ services:
 
   walrus-celery-beat:
     build: .
-    restart: on-failure
+    restart: no
     volumes:
       - ./:/usr/src/app
     env_file:

--- a/listening_profile/admin.py
+++ b/listening_profile/admin.py
@@ -14,7 +14,7 @@ class HistoryPlayLogContextAdmin(admin.ModelAdmin):
 @admin.register(HistoryPlayLog)
 class HistoryPlayLogAdmin(admin.ModelAdmin):
     list_display = ('member', 'track', 'provider', 'played_at', 'context')
-    list_filter = ('provider', 'played_at')
+    list_filter = ('provider', 'member', 'played_at')
     search_fields = ('member__username', 'track__name')
     readonly_fields = ('played_at',)
     date_hierarchy = 'played_at'


### PR DESCRIPTION
Set the restart policy to 'no' for all services in backend-local.yml. This prevents Docker from automatically restarting containers on failure during local development. It provides developers with more control to inspect failed services or manually restart them after making fixes.

✨ feat(admin): add member filter to HistoryPlayLog

Allows administrators to filter play logs by member in the Django admin.