### PR TITLE
🔧 設定(drone)：更新Docker Hub使用者與優化建置快取

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -4,8 +4,8 @@
 
 local VALUES = {
   PROJECT_NAME:             "walrus",
-  DOCKERHUB_USER:           "popopopony",
-  DOCKERHUB_IMAGE:          "popopopony/walrus",
+  DOCKERHUB_USER:           "lislab3morris",
+  DOCKERHUB_IMAGE:          "lislab3morris/walrus",
   K8S_DEPLOYMENT_NAME:      "walrus",
   K8S_DEPLOYMENT_NAMESPACE: "walrus",
   CONTAINER_NAME:           "walrus",
@@ -21,6 +21,12 @@ local SECRET = {
   DOCKER_USERNAME:      { from_secret: "docker-username" },
   DOCKER_PASSWORD:      { from_secret: "docker-password" },
 };
+
+local secret_k8s_server =    { kind: "secret", name: "k8s-server",      get: { path: "k8s-server",      name: "value" } };
+local secret_k8s_token =     { kind: "secret", name: "k8s-token",       get: { path: "k8s-token",       name: "value" } };
+local secret_k8s_ca =        { kind: "secret", name: "k8s-ca",          get: { path: "k8s-ca",          name: "value" } };
+local secret_docker_user =   { kind: "secret", name: "docker-username", get: { path: "docker-username", name: "value" } };
+local secret_docker_pass =   { kind: "secret", name: "docker-password", get: { path: "docker-password", name: "value" } };
 
 
 local CELERY_DEPLOYMENTS = [
@@ -127,6 +133,7 @@ local deploy_pipeline = {
         tags: ["latest", "${DRONE_COMMIT_SHA}"],
         username: SECRET.DOCKER_USERNAME,
         password: SECRET.DOCKER_PASSWORD,
+        cache_from: [VALUES.DOCKERHUB_IMAGE + ":latest"],
       },
     },
     {
@@ -184,4 +191,7 @@ local deploy_pipeline = {
   ],
 };
 
-std.manifestYamlDoc(migration_chack_pipeline) + "\n---\n" + std.manifestYamlDoc(test_pipeline) + "\n---\n" + std.manifestYamlDoc(deploy_pipeline)
+std.join("\n---\n", [
+  std.manifestYamlDoc(p)
+  for p in [migration_chack_pipeline, test_pipeline, deploy_pipeline, secret_k8s_server, secret_k8s_token, secret_k8s_ca, secret_docker_user, secret_docker_pass]
+])

--- a/.drone.yml
+++ b/.drone.yml
@@ -60,18 +60,20 @@
 - "image": "plugins/docker"
   "name": "build and push docker image"
   "settings":
+    "cache_from":
+    - "lislab3morris/walrus:latest"
     "password":
       "from_secret": "docker-password"
-    "repo": "popopopony/walrus"
+    "repo": "lislab3morris/walrus"
     "tags":
     - "latest"
     - "${DRONE_COMMIT_SHA}"
     "username":
       "from_secret": "docker-username"
 - "commands":
-  - "kubectl set image deployment/walrus walrus=popopopony/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl set image deployment/walrus-celery-playlog walrus-celery-playlog=popopopony/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl set image deployment/walrus-celery-beat walrus-celery-beat=popopopony/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
+  - "kubectl set image deployment/walrus walrus=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
+  - "kubectl set image deployment/walrus-celery-playlog walrus-celery-playlog=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
+  - "kubectl set image deployment/walrus-celery-beat walrus-celery-beat=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
   - "kubectl rollout status deployment/walrus --namespace=walrus || exit 1"
   - "kubectl rollout status deployment/walrus-celery-playlog --namespace=walrus || exit 1"
   - "kubectl rollout status deployment/walrus-celery-beat --namespace=walrus || exit 1"
@@ -93,3 +95,33 @@
   "event":
   - "push"
 "type": "kubernetes"
+---
+"get":
+  "name": "value"
+  "path": "k8s-server"
+"kind": "secret"
+"name": "k8s-server"
+---
+"get":
+  "name": "value"
+  "path": "k8s-token"
+"kind": "secret"
+"name": "k8s-token"
+---
+"get":
+  "name": "value"
+  "path": "k8s-ca"
+"kind": "secret"
+"name": "k8s-ca"
+---
+"get":
+  "name": "value"
+  "path": "docker-username"
+"kind": "secret"
+"name": "docker-username"
+---
+"get":
+  "name": "value"
+  "path": "docker-password"
+"kind": "secret"
+"name": "docker-password"


### PR DESCRIPTION
WHAT:
更新Drone配置中的Docker Hub使用者名稱與映像路徑。
從"popopopony"變更為"lislab3morris"。
在Docker建置步驟中新增"cache_from"選項。
在.drone.jsonnet中定義Kubernetes與Docker密鑰變數。
將這些密鑰定義包含在生成的.drone.yml中。
更新Kubernetes部署指令中的映像路徑。

WHY:
將Docker映像推送到新的Docker Hub帳戶。
利用現有映像層加速Docker映像建置時間。
明確定義密鑰以提高配置可讀性與維護性。