### PR TITLE
🔧 設定(drone)：啟用Docker BuildKit並設定內聯快取

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -134,6 +134,8 @@ local deploy_pipeline = {
         username: SECRET.DOCKER_USERNAME,
         password: SECRET.DOCKER_PASSWORD,
         cache_from: [VALUES.DOCKERHUB_IMAGE + ":latest"],
+        buildkit: true,
+        build_args: ["BUILDKIT_INLINE_CACHE=1"],
       },
     },
     {

--- a/.drone.yml
+++ b/.drone.yml
@@ -60,6 +60,9 @@
 - "image": "plugins/docker"
   "name": "build and push docker image"
   "settings":
+    "build_args":
+    - "BUILDKIT_INLINE_CACHE=1"
+    "buildkit": true
     "cache_from":
     - "lislab3morris/walrus:latest"
     "password":

--- a/account/fixtures/experiment_group.json
+++ b/account/fixtures/experiment_group.json
@@ -1,0 +1,38 @@
+[
+  {
+    "model": "account.experimentgroup",
+    "pk": 1,
+    "fields": {
+      "code": "SE",
+      "playlist_length": "short_first",
+      "favorite_track_position": "edge_first"
+    }
+  },
+  {
+    "model": "account.experimentgroup",
+    "pk": 2,
+    "fields": {
+      "code": "SM",
+      "playlist_length": "short_first",
+      "favorite_track_position": "middle_first"
+    }
+  },
+  {
+    "model": "account.experimentgroup",
+    "pk": 3,
+    "fields": {
+      "code": "LE",
+      "playlist_length": "long_first",
+      "favorite_track_position": "edge_first"
+    }
+  },
+  {
+    "model": "account.experimentgroup",
+    "pk": 4,
+    "fields": {
+      "code": "LM",
+      "playlist_length": "long_first",
+      "favorite_track_position": "middle_first"
+    }
+  }
+]

--- a/account/serializers.py
+++ b/account/serializers.py
@@ -4,6 +4,13 @@ from account.models import ExperimentGroup, Member
 from provider.models import Provider
 
 
+class ExperimentGroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ExperimentGroup
+        fields = ['id', 'code', 'playlist_length', 'favorite_track_position']
+        read_only_fields = ['id']
+
+
 class MemberSimpleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Member
@@ -20,12 +27,14 @@ class MemberSerializer(serializers.ModelSerializer):
         choices=[Member.RoleOptions.MEMBER],
         required=True,
     )
-    experiment_group = serializers.PrimaryKeyRelatedField(
+    experiment_group = serializers.SlugRelatedField(
         queryset=ExperimentGroup.objects.all(),
+        slug_field='code',
         required=True,
     )
-    spotify_provider = serializers.PrimaryKeyRelatedField(
+    spotify_provider = serializers.SlugRelatedField(
         queryset=Provider.objects.all(),
+        slug_field='code',
         required=True,
     )
 

--- a/account/urls.py
+++ b/account/urls.py
@@ -1,7 +1,13 @@
 from django.urls import include, path
 from rest_framework import routers
 
-from account.views import LoginView, LogoutView, MemberViewSet, RefreshTokenView
+from account.views import (
+    ExperimentGroupViewSet,
+    LoginView,
+    LogoutView,
+    MemberViewSet,
+    RefreshTokenView,
+)
 
 app_name = 'account'
 
@@ -10,6 +16,9 @@ member_router = routers.DefaultRouter()
 
 staff_router = routers.DefaultRouter()
 staff_router.register(r'members', MemberViewSet, basename='member')
+staff_router.register(
+    r'experiment-groups', ExperimentGroupViewSet, basename='experiment-group'
+)
 
 
 urlpatterns = [

--- a/account/views.py
+++ b/account/views.py
@@ -3,9 +3,10 @@ from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveMode
 from rest_framework.permissions import IsAuthenticated
 
 from account.jwt import JWTService
-from account.models import Member
+from account.models import ExperimentGroup, Member
 from account.permissions import IsStaff
 from account.serializers import (
+    ExperimentGroupSerializer,
     LoginSerializer,
     MemberSerializer,
     MemberSimpleSerializer,
@@ -77,6 +78,12 @@ class LogoutView(BaseAPIView):
                 code=ResponseCode.INVALID_TOKEN,
                 msg='無效的 token',
             )
+
+
+class ExperimentGroupViewSet(ListModelMixin, BaseGenericViewSet):
+    permission_classes = [IsStaff]
+    serializer_class = ExperimentGroupSerializer
+    queryset = ExperimentGroup.objects.all()
 
 
 class MemberViewSet(

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 
 python manage.py migrate
 python manage.py collectstatic --noinput
+python manage.py loaddata account/fixtures/experiment_group.json
 
 python manage.py register_periodic_tasks
 

--- a/provider/tasks.py
+++ b/provider/tasks.py
@@ -84,6 +84,19 @@ def update_artists_details(artist_ids, member_id):
     return [a.external_id for a in artists_to_update]
 
 
+def _get_valid_staff_member():
+    for candidate in Member.objects.filter(
+        role=Member.RoleOptions.STAFF,
+        spotify_provider__isnull=False,
+    ):
+        handler = SpotifyAPIProviderHandler(
+            candidate.spotify_provider, member=candidate
+        )
+        if handler.refresh_token():
+            return candidate
+    return None
+
+
 @shared_task(queue='playlog_q')
 def check_and_update_missing_artist_details():
     """
@@ -91,9 +104,9 @@ def check_and_update_missing_artist_details():
 
     分批處理以避免 Spotify API 限制（一次最多 50 個）
     """
-    staff_member = Member.objects.filter(role=Member.RoleOptions.STAFF).first()
+    staff_member = _get_valid_staff_member()
     if not staff_member:
-        logger.warning('No staff member found for updating artist details')
+        logger.warning('No valid staff member found for updating artist details')
         return
 
     # 查詢所有 Spotify platform 缺少詳細資訊的 artists
@@ -196,9 +209,11 @@ def check_and_update_missing_playlist_context_details():
 
     定期執行，批次處理需要更新的 contexts
     """
-    staff_member = Member.objects.filter(role=Member.RoleOptions.STAFF).first()
+    staff_member = _get_valid_staff_member()
     if not staff_member:
-        logger.warning('No staff member found for updating playlist context details')
+        logger.warning(
+            'No valid staff member found for updating playlist context details'
+        )
         return
 
     # 查詢所有 playlist 類型且缺少 details 的 contexts


### PR DESCRIPTION
✨ 功能(account)：新增ExperimentGroup模型序列化器與視圖集
✨ 功能(account)：新增實驗組別的固定資料
♻️ 重構(account)：將Member序列化器中的關聯欄位改為SlugRelatedField ✨ 功能(account)：新增ExperimentGroup API路由
🐛 修正(provider)：新增_get_valid_staff_member輔助函數以尋找有效的員工成員 ♻️ 重構(provider)：使用_get_valid_staff_member函數來獲取員工成員 🚀 部署(entrypoint)：在啟動時載入實驗組別固定資料