### PR TITLE
🔧 feat(settings.py)：允許透過環境變數設定DEBUG模式

### DIFF
--- a/walrus/settings.py
+++ b/walrus/settings.py
@@ -28,7 +28,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 ENV = os.environ.get('ENV', 'local')
 
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
將DEBUG設定從硬編碼的True改為從環境變數讀取。
若環境變數未設定，則預設為False。

此變更旨在提高應用程式的安全性與靈活性，
避免在生產環境中意外啟用調試模式。