### PR TITLE
✨ feat(ci): 提升 CI/CD 流程，引入發佈與清理階段

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -4,49 +4,46 @@
 
 local VALUES = {
   PROJECT_NAME:             "walrus",
-  DOCKERHUB_USER:           "lislab3morris",
   DOCKERHUB_IMAGE:          "lislab3morris/walrus",
   K8S_DEPLOYMENT_NAME:      "walrus",
   K8S_DEPLOYMENT_NAMESPACE: "walrus",
-  CONTAINER_NAME:           "walrus",
   BRANCH:                   "master",
 };
 
-
-
-local SECRET = {
-  DOCKER_USERNAME:      { from_secret: "docker-username" },
-  DOCKER_PASSWORD:      { from_secret: "docker-password" },
-};
-
-local secret_docker_user =   { kind: "secret", name: "docker-username", get: { path: "docker-username", name: "value" } };
-local secret_docker_pass =   { kind: "secret", name: "docker-password", get: { path: "docker-password", name: "value" } };
-
-
 local CELERY_DEPLOYMENTS = [
   "%s-celery-playlog" % VALUES.K8S_DEPLOYMENT_NAME,
-  "%s-celery-beat" % VALUES.K8S_DEPLOYMENT_NAME,
+  "%s-celery-beat"    % VALUES.K8S_DEPLOYMENT_NAME,
 ];
 
+local ALL_DEPLOYMENTS = [VALUES.K8S_DEPLOYMENT_NAME] + CELERY_DEPLOYMENTS;
 
-local migration_chack_pipeline = {
+local SECRET = {
+  DOCKER_USERNAME: { from_secret: "docker-username" },
+  DOCKER_PASSWORD: { from_secret: "docker-password" },
+};
+
+local secret_docker_user = { kind: "secret", name: "docker-username", get: { path: "docker-username", name: "value" } };
+local secret_docker_pass = { kind: "secret", name: "docker-password", get: { path: "docker-password", name: "value" } };
+
+local node = { repo: "Lab3-Spotify-walrus" };
+
+local trigger = {
+  event:  ["push"],
+  branch: [VALUES.BRANCH],
+};
+
+// ── migration check ───────────────────────────────────────
+local migrationCheckPipeline = {
   kind: "pipeline",
   type: "kubernetes",
   name: "walrus-migration-check",
-  node: {
-    // should be equal to DRONE_RUNNER_LABELS in drone-runner
-    repo: "Lab3-Spotify-walrus",
-  },
-  trigger: {
-    event: ["pull_request"],
-  },
+  node: node,
+  trigger: { event: ["pull_request"] },
   steps: [
     {
       name:  "migration-dry-run",
       image: "python:3.10.13-slim",
-      environment:{
-        DJANGO_SECRET_KEY: "MIGRATION_CHECK_PIPELINE_SUPER_SECRET"
-      },
+      environment: { DJANGO_SECRET_KEY: "MIGRATION_CHECK_PIPELINE_SUPER_SECRET" },
       commands: [
         "pip install poetry==1.6.1 poetry-plugin-export",
         "poetry export -f requirements.txt --without-hashes -o requirements.txt",
@@ -58,47 +55,39 @@ local migration_chack_pipeline = {
   ],
 };
 
-local test_pipeline = {
+// ── test ──────────────────────────────────────────────────
+local testPipeline = {
   kind: "pipeline",
   type: "kubernetes",
   name: "walrus-test",
-  node: {
-    // should be equal to DRONE_RUNNER_LABELS in drone-runner
-    repo: "Lab3-Spotify-walrus",
-  },
-  trigger: {
-    event:  ["push"],
-    branch: [ VALUES.BRANCH ],
-  },
+  node: node,
+  trigger: trigger,
   services: [
     {
-      name: "walrus-test-db",
+      name:  "walrus-test-db",
       image: "postgres:14-alpine",
       environment: {
-        POSTGRES_USER: "walrus-test",
+        POSTGRES_USER:     "walrus-test",
         POSTGRES_PASSWORD: "walrus-test",
-        POSTGRES_DB: "walrus-test",
+        POSTGRES_DB:       "walrus-test",
       },
     },
-    {
-      name: "walrus-test-redis",
-      image: "redis:7.4.2",
-    },
+    { name: "walrus-test-redis", image: "redis:7.4.2" },
   ],
   steps: [
     {
       name:  "install-and-test",
       image: "python:3.10.13-slim",
       environment: {
-        ENV:                    "test",
-        DJANGO_SECRET_KEY:      "TEST_PIPELINE_SUPER_SECRET",
-        POSTGRES_HOST:          "walrus-test-db",
-        POSTGRES_USER:          "walrus-test",
-        POSTGRES_PASSWORD:      "walrus-test",
-        POSTGRES_DB:            "walrus-test",
-        POSTGRES_PORT:          "5432",
-        REDIS_HOST:             "walrus-test-redis",
-        REDIS_PORT:             "6379",
+        ENV:               "test",
+        DJANGO_SECRET_KEY: "TEST_PIPELINE_SUPER_SECRET",
+        POSTGRES_HOST:     "walrus-test-db",
+        POSTGRES_USER:     "walrus-test",
+        POSTGRES_PASSWORD: "walrus-test",
+        POSTGRES_DB:       "walrus-test",
+        POSTGRES_PORT:     "5432",
+        REDIS_HOST:        "walrus-test-redis",
+        REDIS_PORT:        "6379",
       },
       commands: [
         "pip install poetry==1.6.1 poetry-plugin-export",
@@ -110,81 +99,118 @@ local test_pipeline = {
   ],
 };
 
-local deploy_pipeline = {
+// ── build ─────────────────────────────────────────────────
+local buildPipeline = {
   kind: "pipeline",
   type: "kubernetes",
-  name: "walrus-deploy",
-  node: {
-    // should be equal to DRONE_RUNNER_LABELS in drone-runner
-    repo: "Lab3-Spotify-walrus",
-  },
-  trigger: {
-    event:  ["push"],
-    branch: [ VALUES.BRANCH ],
-  },
+  name: "walrus-build",
+  node: node,
+  depends_on: ["walrus-test"],
+  trigger: trigger,
   steps: [
     {
-      name:  "build and push docker image",
+      name:  "build",
       image: "plugins/docker",
       settings: {
-        repo:  VALUES.DOCKERHUB_IMAGE,
-        tags: ["latest", "${DRONE_COMMIT_SHA}"],
-        username: SECRET.DOCKER_USERNAME,
-        password: SECRET.DOCKER_PASSWORD,
+        repo:       VALUES.DOCKERHUB_IMAGE,
+        tags:       ["test-${DRONE_COMMIT_SHA}"],
+        username:   SECRET.DOCKER_USERNAME,
+        password:   SECRET.DOCKER_PASSWORD,
         cache_from: [VALUES.DOCKERHUB_IMAGE + ":latest"],
-        buildkit: true,
+        buildkit:   true,
         build_args: ["BUILDKIT_INLINE_CACHE=1"],
       },
-    },
-    {
-      name:  "deploy to k8s",
-      image: "bitnami/kubectl",
-      // commands: [
-      //   std.format(
-      //     "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
-      //     [VALUES.K8S_DEPLOYMENT_NAME, VALUES.CONTAINER_NAME, VALUES.DOCKERHUB_IMAGE, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-      //   ),
-      //   std.format(
-      //     "kubectl rollout status deployment/%s --namespace=%s || exit 1",
-      //     [VALUES.K8S_DEPLOYMENT_NAME, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-      //   ),
-      //   "echo Deployment success!",
-      // ],
-      commands: [
-        std.format(
-          "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
-          [VALUES.K8S_DEPLOYMENT_NAME, VALUES.CONTAINER_NAME, VALUES.DOCKERHUB_IMAGE, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-        ),
-      ] +
-      std.map(
-        function(name)
-          std.format(
-            "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
-            [name, name, VALUES.DOCKERHUB_IMAGE, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-          ),
-        CELERY_DEPLOYMENTS
-      ) +
-      [
-        std.format(
-          "kubectl rollout status deployment/%s --namespace=%s || exit 1",
-          [VALUES.K8S_DEPLOYMENT_NAME, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-        ),
-      ] +
-      std.map(
-        function(name)
-          std.format(
-            "kubectl rollout status deployment/%s --namespace=%s || exit 1",
-            [name, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-          ),
-        CELERY_DEPLOYMENTS
-      ) + [
-        "echo Deployment success!",
-      ]
     },
   ],
 };
 
+// ── publish ───────────────────────────────────────────────
+local publishPipeline = {
+  kind: "pipeline",
+  type: "kubernetes",
+  name: "walrus-publish",
+  node: node,
+  depends_on: ["walrus-build"],
+  trigger: trigger,
+  steps: [
+    {
+      name:  "promote",
+      image: "regclient/regctl:edge-alpine",
+      environment: {
+        DOCKER_USERNAME: SECRET.DOCKER_USERNAME,
+        DOCKER_PASSWORD: SECRET.DOCKER_PASSWORD,
+      },
+      commands: [
+        "regctl registry login registry-1.docker.io -u $DOCKER_USERNAME -p $DOCKER_PASSWORD",
+        "regctl image copy %(img)s:test-${DRONE_COMMIT_SHA} %(img)s:${DRONE_COMMIT_SHA}" % { img: VALUES.DOCKERHUB_IMAGE },
+        "regctl image copy %(img)s:test-${DRONE_COMMIT_SHA} %(img)s:latest"              % { img: VALUES.DOCKERHUB_IMAGE },
+        "regctl tag delete %s:test-${DRONE_COMMIT_SHA}"                                  % VALUES.DOCKERHUB_IMAGE,
+      ],
+    },
+  ],
+};
+
+// ── deploy ────────────────────────────────────────────────
+local deployPipeline = {
+  kind: "pipeline",
+  type: "kubernetes",
+  name: "walrus-deploy",
+  node: node,
+  depends_on: ["walrus-publish"],
+  trigger: trigger,
+  steps: [
+    {
+      name:  "deploy",
+      image: "bitnami/kubectl",
+      commands: std.map(
+        function(name) "kubectl rollout restart deployment/%s -n %s" % [name, VALUES.K8S_DEPLOYMENT_NAMESPACE],
+        ALL_DEPLOYMENTS
+      ),
+    },
+    {
+      name:  "verify",
+      image: "bitnami/kubectl",
+      commands: std.map(
+        function(name) "kubectl rollout status deployment/%s -n %s --timeout=120s || exit 1" % [name, VALUES.K8S_DEPLOYMENT_NAMESPACE],
+        ALL_DEPLOYMENTS
+      ),
+    },
+    {
+      name:  "cleanup-old-tags",
+      image: "alpine:3",
+      environment: {
+        DOCKER_USERNAME: SECRET.DOCKER_USERNAME,
+        DOCKER_PASSWORD: SECRET.DOCKER_PASSWORD,
+      },
+      commands: [
+        "apk add --no-cache curl jq",
+        |||
+          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"$DOCKER_USERNAME\",\"password\":\"$DOCKER_PASSWORD\"}" \
+            | jq -r .token)
+          curl -s "https://hub.docker.com/v2/repositories/%(img)s/tags/?page_size=100" \
+            -H "Authorization: JWT $TOKEN" \
+            | jq -r '[.results[] | select(.name | test("^[0-9a-f]{40}$")) | .name] | .[5:] | .[]' \
+            | xargs -r -I{} curl -s -X DELETE \
+              "https://hub.docker.com/v2/repositories/%(img)s/tags/{}/" \
+              -H "Authorization: JWT $TOKEN"
+        ||| % { img: VALUES.DOCKERHUB_IMAGE },
+      ],
+    },
+  ],
+};
+
+// ── output ────────────────────────────────────────────────
 std.join("\n---\n", [
   std.manifestYamlDoc(p)
-  for p in [migration_chack_pipeline, test_pipeline, deploy_pipeline, secret_docker_user, secret_docker_pass]
+  for p in [
+    migrationCheckPipeline,
+    testPipeline,
+    buildPipeline,
+    publishPipeline,
+    deployPipeline,
+    secret_docker_user,
+    secret_docker_pass,
+  ]
 ])

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,13 +56,15 @@
   - "push"
 "type": "kubernetes"
 ---
+"depends_on":
+- "walrus-test"
 "kind": "pipeline"
-"name": "walrus-deploy"
+"name": "walrus-build"
 "node":
   "repo": "Lab3-Spotify-walrus"
 "steps":
 - "image": "plugins/docker"
-  "name": "build and push docker image"
+  "name": "build"
   "settings":
     "build_args":
     - "BUILDKIT_INLINE_CACHE=1"
@@ -73,20 +75,81 @@
       "from_secret": "docker-password"
     "repo": "lislab3morris/walrus"
     "tags":
-    - "latest"
-    - "${DRONE_COMMIT_SHA}"
+    - "test-${DRONE_COMMIT_SHA}"
     "username":
       "from_secret": "docker-username"
+"trigger":
+  "branch":
+  - "master"
+  "event":
+  - "push"
+"type": "kubernetes"
+---
+"depends_on":
+- "walrus-build"
+"kind": "pipeline"
+"name": "walrus-publish"
+"node":
+  "repo": "Lab3-Spotify-walrus"
+"steps":
 - "commands":
-  - "kubectl set image deployment/walrus walrus=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl set image deployment/walrus-celery-playlog walrus-celery-playlog=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl set image deployment/walrus-celery-beat walrus-celery-beat=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl rollout status deployment/walrus --namespace=walrus || exit 1"
-  - "kubectl rollout status deployment/walrus-celery-playlog --namespace=walrus || exit 1"
-  - "kubectl rollout status deployment/walrus-celery-beat --namespace=walrus || exit 1"
-  - "echo Deployment success!"
+  - "regctl registry login registry-1.docker.io -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+  - "regctl image copy lislab3morris/walrus:test-${DRONE_COMMIT_SHA} lislab3morris/walrus:${DRONE_COMMIT_SHA}"
+  - "regctl image copy lislab3morris/walrus:test-${DRONE_COMMIT_SHA} lislab3morris/walrus:latest"
+  - "regctl tag delete lislab3morris/walrus:test-${DRONE_COMMIT_SHA}"
+  "environment":
+    "DOCKER_PASSWORD":
+      "from_secret": "docker-password"
+    "DOCKER_USERNAME":
+      "from_secret": "docker-username"
+  "image": "regclient/regctl:edge-alpine"
+  "name": "promote"
+"trigger":
+  "branch":
+  - "master"
+  "event":
+  - "push"
+"type": "kubernetes"
+---
+"depends_on":
+- "walrus-publish"
+"kind": "pipeline"
+"name": "walrus-deploy"
+"node":
+  "repo": "Lab3-Spotify-walrus"
+"steps":
+- "commands":
+  - "kubectl rollout restart deployment/walrus -n walrus"
+  - "kubectl rollout restart deployment/walrus-celery-playlog -n walrus"
+  - "kubectl rollout restart deployment/walrus-celery-beat -n walrus"
   "image": "bitnami/kubectl"
-  "name": "deploy to k8s"
+  "name": "deploy"
+- "commands":
+  - "kubectl rollout status deployment/walrus -n walrus --timeout=120s || exit 1"
+  - "kubectl rollout status deployment/walrus-celery-playlog -n walrus --timeout=120s || exit 1"
+  - "kubectl rollout status deployment/walrus-celery-beat -n walrus --timeout=120s || exit 1"
+  "image": "bitnami/kubectl"
+  "name": "verify"
+- "commands":
+  - "apk add --no-cache curl jq"
+  - |
+    TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login" \
+      -H "Content-Type: application/json" \
+      -d "{\"username\":\"$DOCKER_USERNAME\",\"password\":\"$DOCKER_PASSWORD\"}" \
+      | jq -r .token)
+    curl -s "https://hub.docker.com/v2/repositories/lislab3morris/walrus/tags/?page_size=100" \
+      -H "Authorization: JWT $TOKEN" \
+      | jq -r '[.results[] | select(.name | test("^[0-9a-f]{40}$")) | .name] | .[5:] | .[]' \
+      | xargs -r -I{} curl -s -X DELETE \
+        "https://hub.docker.com/v2/repositories/lislab3morris/walrus/tags/{}/" \
+        -H "Authorization: JWT $TOKEN"
+  "environment":
+    "DOCKER_PASSWORD":
+      "from_secret": "docker-password"
+    "DOCKER_USERNAME":
+      "from_secret": "docker-username"
+  "image": "alpine:3"
+  "name": "cleanup-old-tags"
 "trigger":
   "branch":
   - "master"


### PR DESCRIPTION
將原部署流水線拆分為建置、發佈與部署三個獨立階段。
新增發佈流水線，負責將測試映像檔提升為正式標籤。
新增部署後自動清理 Docker Hub 舊映像檔標籤的機制。
重構 Drone 配置，提取常用變數並新增註解以提高可讀性。
更新 Kubernetes 部署命令為 `rollout restart`。

此變更旨在提升 CI/CD 流程的可靠性與可維護性。透過
發佈階段確保映像檔品質，並自動清理舊標籤以優化儲存。