### PR TITLE
✨ feat(ci)：增強CI/CD流程，新增服務等待與Docker標籤清理

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,190 +1,183 @@
 // output to .drone.yml (which drone really reads)
-// jsonnet .drone.jsonnet | jq . | yq -P - > .drone.yml
-
+// jsonnet .drone.jsonnet | yq -P - > .drone.yml
 
 local VALUES = {
   PROJECT_NAME:             "walrus",
-  DOCKERHUB_USER:           "lislab3morris",
   DOCKERHUB_IMAGE:          "lislab3morris/walrus",
   K8S_DEPLOYMENT_NAME:      "walrus",
   K8S_DEPLOYMENT_NAMESPACE: "walrus",
-  CONTAINER_NAME:           "walrus",
   BRANCH:                   "master",
 };
 
-
-
-local SECRET = {
-  DOCKER_USERNAME:      { from_secret: "docker-username" },
-  DOCKER_PASSWORD:      { from_secret: "docker-password" },
-};
-
-local secret_docker_user =   { kind: "secret", name: "docker-username", get: { path: "docker-username", name: "value" } };
-local secret_docker_pass =   { kind: "secret", name: "docker-password", get: { path: "docker-password", name: "value" } };
-
-
 local CELERY_DEPLOYMENTS = [
   "%s-celery-playlog" % VALUES.K8S_DEPLOYMENT_NAME,
-  "%s-celery-beat" % VALUES.K8S_DEPLOYMENT_NAME,
+  "%s-celery-beat"    % VALUES.K8S_DEPLOYMENT_NAME,
 ];
 
+local ALL_DEPLOYMENTS = [VALUES.K8S_DEPLOYMENT_NAME] + CELERY_DEPLOYMENTS;
 
-local migration_chack_pipeline = {
-  kind: "pipeline",
-  type: "kubernetes",
-  name: "walrus-migration-check",
-  node: {
-    // should be equal to DRONE_RUNNER_LABELS in drone-runner
-    repo: "Lab3-Spotify-walrus",
-  },
-  trigger: {
-    event: ["pull_request"],
-  },
-  steps: [
-    {
-      name:  "migration-dry-run",
-      image: "python:3.10.13-slim",
-      environment:{
-        DJANGO_SECRET_KEY: "MIGRATION_CHECK_PIPELINE_SUPER_SECRET"
-      },
-      commands: [
-        "pip install poetry==1.6.1 poetry-plugin-export",
-        "poetry export -f requirements.txt --without-hashes -o requirements.txt",
-        "pip install -r requirements.txt || exit 1",
-        "python manage.py check || exit 1",
-        "python manage.py makemigrations --dry-run --check",
-      ],
-    },
-  ],
+local SECRET = {
+  DOCKER_USERNAME: { from_secret: "docker-username" },
+  DOCKER_PASSWORD: { from_secret: "docker-password" },
 };
 
-local test_pipeline = {
+local secret_docker_user = { kind: "secret", name: "docker-username", get: { path: "docker-username", name: "value" } };
+local secret_docker_pass = { kind: "secret", name: "docker-password", get: { path: "docker-password", name: "value" } };
+
+local node = { repo: "Lab3-Spotify-walrus" };
+
+local trigger = {
+  event:  ["push"],
+  branch: [VALUES.BRANCH],
+};
+
+// ── test ──────────────────────────────────────────────────
+local testPipeline = {
   kind: "pipeline",
   type: "kubernetes",
   name: "walrus-test",
-  node: {
-    // should be equal to DRONE_RUNNER_LABELS in drone-runner
-    repo: "Lab3-Spotify-walrus",
-  },
-  trigger: {
-    event:  ["push"],
-    branch: [ VALUES.BRANCH ],
-  },
+  node: node,
+  trigger: trigger,
   services: [
     {
-      name: "walrus-test-db",
+      name:  "walrus-test-db",
       image: "postgres:14-alpine",
       environment: {
-        POSTGRES_USER: "walrus-test",
+        POSTGRES_USER:     "walrus-test",
         POSTGRES_PASSWORD: "walrus-test",
-        POSTGRES_DB: "walrus-test",
+        POSTGRES_DB:       "walrus-test",
       },
     },
-    {
-      name: "walrus-test-redis",
-      image: "redis:7.4.2",
-    },
+    { name: "walrus-test-redis", image: "redis:7.4.2" },
   ],
   steps: [
     {
       name:  "install-and-test",
       image: "python:3.10.13-slim",
       environment: {
-        ENV:                    "test",
-        DJANGO_SECRET_KEY:      "TEST_PIPELINE_SUPER_SECRET",
-        POSTGRES_HOST:          "walrus-test-db",
-        POSTGRES_USER:          "walrus-test",
-        POSTGRES_PASSWORD:      "walrus-test",
-        POSTGRES_DB:            "walrus-test",
-        POSTGRES_PORT:          "5432",
-        REDIS_HOST:             "walrus-test-redis",
-        REDIS_PORT:             "6379",
+        ENV:               "test",
+        DJANGO_SECRET_KEY: "TEST_PIPELINE_SUPER_SECRET",
+        POSTGRES_HOST:     "walrus-test-db",
+        POSTGRES_USER:     "walrus-test",
+        POSTGRES_PASSWORD: "walrus-test",
+        POSTGRES_DB:       "walrus-test",
+        POSTGRES_PORT:     "5432",
+        REDIS_HOST:        "walrus-test-redis",
+        REDIS_PORT:        "6379",
       },
       commands: [
         "pip install poetry==1.6.1 poetry-plugin-export",
         "poetry export -f requirements.txt --without-hashes -o requirements.txt",
         "pip install -r requirements.txt || exit 1",
+        "python ci/wait-for-db.py",
+        "python ci/wait-for-redis.py",
         "python manage.py test || exit 1",
       ],
     },
   ],
 };
 
-local deploy_pipeline = {
+// ── build ─────────────────────────────────────────────────
+local buildPipeline = {
   kind: "pipeline",
   type: "kubernetes",
-  name: "walrus-deploy",
-  node: {
-    // should be equal to DRONE_RUNNER_LABELS in drone-runner
-    repo: "Lab3-Spotify-walrus",
-  },
-  trigger: {
-    event:  ["push"],
-    branch: [ VALUES.BRANCH ],
-  },
+  name: "walrus-build",
+  node: node,
+  depends_on: ["walrus-test"],
+  trigger: trigger,
   steps: [
     {
-      name:  "build and push docker image",
+      name:  "build",
       image: "plugins/docker",
       settings: {
-        repo:  VALUES.DOCKERHUB_IMAGE,
-        tags: ["latest", "${DRONE_COMMIT_SHA}"],
-        username: SECRET.DOCKER_USERNAME,
-        password: SECRET.DOCKER_PASSWORD,
+        repo:       VALUES.DOCKERHUB_IMAGE,
+        tags:       ["test-${DRONE_COMMIT_SHA}"],
+        username:   SECRET.DOCKER_USERNAME,
+        password:   SECRET.DOCKER_PASSWORD,
         cache_from: [VALUES.DOCKERHUB_IMAGE + ":latest"],
-        buildkit: true,
+        buildkit:   true,
         build_args: ["BUILDKIT_INLINE_CACHE=1"],
       },
-    },
-    {
-      name:  "deploy to k8s",
-      image: "bitnami/kubectl",
-      // commands: [
-      //   std.format(
-      //     "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
-      //     [VALUES.K8S_DEPLOYMENT_NAME, VALUES.CONTAINER_NAME, VALUES.DOCKERHUB_IMAGE, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-      //   ),
-      //   std.format(
-      //     "kubectl rollout status deployment/%s --namespace=%s || exit 1",
-      //     [VALUES.K8S_DEPLOYMENT_NAME, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-      //   ),
-      //   "echo Deployment success!",
-      // ],
-      commands: [
-        std.format(
-          "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
-          [VALUES.K8S_DEPLOYMENT_NAME, VALUES.CONTAINER_NAME, VALUES.DOCKERHUB_IMAGE, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-        ),
-      ] +
-      std.map(
-        function(name)
-          std.format(
-            "kubectl set image deployment/%s %s=%s:${DRONE_COMMIT_SHA} --namespace=%s || exit 1",
-            [name, name, VALUES.DOCKERHUB_IMAGE, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-          ),
-        CELERY_DEPLOYMENTS
-      ) +
-      [
-        std.format(
-          "kubectl rollout status deployment/%s --namespace=%s || exit 1",
-          [VALUES.K8S_DEPLOYMENT_NAME, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-        ),
-      ] +
-      std.map(
-        function(name)
-          std.format(
-            "kubectl rollout status deployment/%s --namespace=%s || exit 1",
-            [name, VALUES.K8S_DEPLOYMENT_NAMESPACE]
-          ),
-        CELERY_DEPLOYMENTS
-      ) + [
-        "echo Deployment success!",
-      ]
     },
   ],
 };
 
+// ── publish ───────────────────────────────────────────────
+local publishPipeline = {
+  kind: "pipeline",
+  type: "kubernetes",
+  name: "walrus-publish",
+  node: node,
+  depends_on: ["walrus-build"],
+  trigger: trigger,
+  steps: [
+    {
+      name:  "promote",
+      image: "regclient/regctl:edge-alpine",
+      environment: {
+        DOCKER_USERNAME: SECRET.DOCKER_USERNAME,
+        DOCKER_PASSWORD: SECRET.DOCKER_PASSWORD,
+      },
+      commands: [
+        "regctl registry login registry-1.docker.io -u $DOCKER_USERNAME -p $DOCKER_PASSWORD",
+        "regctl image copy %(img)s:test-${DRONE_COMMIT_SHA} %(img)s:${DRONE_COMMIT_SHA}" % { img: VALUES.DOCKERHUB_IMAGE },
+        "regctl image copy %(img)s:test-${DRONE_COMMIT_SHA} %(img)s:latest"              % { img: VALUES.DOCKERHUB_IMAGE },
+        "regctl tag delete %s:test-${DRONE_COMMIT_SHA}"                                  % VALUES.DOCKERHUB_IMAGE,
+      ],
+    },
+  ],
+};
+
+// ── deploy ────────────────────────────────────────────────
+local deployPipeline = {
+  kind: "pipeline",
+  type: "kubernetes",
+  name: "walrus-deploy",
+  node: node,
+  depends_on: ["walrus-publish"],
+  trigger: trigger,
+  steps: [
+    {
+      name:  "deploy",
+      image: "bitnami/kubectl",
+      commands: std.map(
+        function(name) "kubectl rollout restart deployment/%s -n %s || exit 1" % [name, VALUES.K8S_DEPLOYMENT_NAMESPACE],
+        ALL_DEPLOYMENTS
+      ),
+    },
+    {
+      name:  "verify",
+      image: "bitnami/kubectl",
+      commands: std.map(
+        function(name) "kubectl rollout status deployment/%s -n %s --timeout=120s || exit 1" % [name, VALUES.K8S_DEPLOYMENT_NAMESPACE],
+        ALL_DEPLOYMENTS
+      ),
+    },
+    {
+      name:  "cleanup-old-tags",
+      image: "alpine:3",
+      environment: {
+        DOCKER_USERNAME: SECRET.DOCKER_USERNAME,
+        DOCKER_PASSWORD: SECRET.DOCKER_PASSWORD,
+        REPO_PATH:       VALUES.DOCKERHUB_IMAGE,
+      },
+      commands: [
+        "apk add --no-cache curl jq",
+        "sh ci/cleanup-dockerhub.sh",
+      ],
+    },
+  ],
+};
+
+// ── output ────────────────────────────────────────────────
 std.join("\n---\n", [
   std.manifestYamlDoc(p)
-  for p in [migration_chack_pipeline, test_pipeline, deploy_pipeline, secret_docker_user, secret_docker_pass]
+  for p in [
+    testPipeline,
+    buildPipeline,
+    publishPipeline,
+    deployPipeline,
+    secret_docker_user,
+    secret_docker_pass,
+  ]
 ])

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,24 +1,4 @@
 "kind": "pipeline"
-"name": "walrus-migration-check"
-"node":
-  "repo": "Lab3-Spotify-walrus"
-"steps":
-- "commands":
-  - "pip install poetry==1.6.1 poetry-plugin-export"
-  - "poetry export -f requirements.txt --without-hashes -o requirements.txt"
-  - "pip install -r requirements.txt || exit 1"
-  - "python manage.py check || exit 1"
-  - "python manage.py makemigrations --dry-run --check"
-  "environment":
-    "DJANGO_SECRET_KEY": "MIGRATION_CHECK_PIPELINE_SUPER_SECRET"
-  "image": "python:3.10.13-slim"
-  "name": "migration-dry-run"
-"trigger":
-  "event":
-  - "pull_request"
-"type": "kubernetes"
----
-"kind": "pipeline"
 "name": "walrus-test"
 "node":
   "repo": "Lab3-Spotify-walrus"
@@ -36,6 +16,8 @@
   - "pip install poetry==1.6.1 poetry-plugin-export"
   - "poetry export -f requirements.txt --without-hashes -o requirements.txt"
   - "pip install -r requirements.txt || exit 1"
+  - "python ci/wait-for-db.py"
+  - "python ci/wait-for-redis.py"
   - "python manage.py test || exit 1"
   "environment":
     "DJANGO_SECRET_KEY": "TEST_PIPELINE_SUPER_SECRET"
@@ -56,13 +38,15 @@
   - "push"
 "type": "kubernetes"
 ---
+"depends_on":
+- "walrus-test"
 "kind": "pipeline"
-"name": "walrus-deploy"
+"name": "walrus-build"
 "node":
   "repo": "Lab3-Spotify-walrus"
 "steps":
 - "image": "plugins/docker"
-  "name": "build and push docker image"
+  "name": "build"
   "settings":
     "build_args":
     - "BUILDKIT_INLINE_CACHE=1"
@@ -73,20 +57,72 @@
       "from_secret": "docker-password"
     "repo": "lislab3morris/walrus"
     "tags":
-    - "latest"
-    - "${DRONE_COMMIT_SHA}"
+    - "test-${DRONE_COMMIT_SHA}"
     "username":
       "from_secret": "docker-username"
+"trigger":
+  "branch":
+  - "master"
+  "event":
+  - "push"
+"type": "kubernetes"
+---
+"depends_on":
+- "walrus-build"
+"kind": "pipeline"
+"name": "walrus-publish"
+"node":
+  "repo": "Lab3-Spotify-walrus"
+"steps":
 - "commands":
-  - "kubectl set image deployment/walrus walrus=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl set image deployment/walrus-celery-playlog walrus-celery-playlog=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl set image deployment/walrus-celery-beat walrus-celery-beat=lislab3morris/walrus:${DRONE_COMMIT_SHA} --namespace=walrus || exit 1"
-  - "kubectl rollout status deployment/walrus --namespace=walrus || exit 1"
-  - "kubectl rollout status deployment/walrus-celery-playlog --namespace=walrus || exit 1"
-  - "kubectl rollout status deployment/walrus-celery-beat --namespace=walrus || exit 1"
-  - "echo Deployment success!"
+  - "regctl registry login registry-1.docker.io -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+  - "regctl image copy lislab3morris/walrus:test-${DRONE_COMMIT_SHA} lislab3morris/walrus:${DRONE_COMMIT_SHA}"
+  - "regctl image copy lislab3morris/walrus:test-${DRONE_COMMIT_SHA} lislab3morris/walrus:latest"
+  - "regctl tag delete lislab3morris/walrus:test-${DRONE_COMMIT_SHA}"
+  "environment":
+    "DOCKER_PASSWORD":
+      "from_secret": "docker-password"
+    "DOCKER_USERNAME":
+      "from_secret": "docker-username"
+  "image": "regclient/regctl:edge-alpine"
+  "name": "promote"
+"trigger":
+  "branch":
+  - "master"
+  "event":
+  - "push"
+"type": "kubernetes"
+---
+"depends_on":
+- "walrus-publish"
+"kind": "pipeline"
+"name": "walrus-deploy"
+"node":
+  "repo": "Lab3-Spotify-walrus"
+"steps":
+- "commands":
+  - "kubectl rollout restart deployment/walrus -n walrus || exit 1"
+  - "kubectl rollout restart deployment/walrus-celery-playlog -n walrus || exit 1"
+  - "kubectl rollout restart deployment/walrus-celery-beat -n walrus || exit 1"
   "image": "bitnami/kubectl"
-  "name": "deploy to k8s"
+  "name": "deploy"
+- "commands":
+  - "kubectl rollout status deployment/walrus -n walrus --timeout=120s || exit 1"
+  - "kubectl rollout status deployment/walrus-celery-playlog -n walrus --timeout=120s || exit 1"
+  - "kubectl rollout status deployment/walrus-celery-beat -n walrus --timeout=120s || exit 1"
+  "image": "bitnami/kubectl"
+  "name": "verify"
+- "commands":
+  - "apk add --no-cache curl jq"
+  - "sh ci/cleanup-dockerhub.sh"
+  "environment":
+    "DOCKER_PASSWORD":
+      "from_secret": "docker-password"
+    "DOCKER_USERNAME":
+      "from_secret": "docker-username"
+    "REPO_PATH": "lislab3morris/walrus"
+  "image": "alpine:3"
+  "name": "cleanup-old-tags"
 "trigger":
   "branch":
   - "master"

--- a/ci/cleanup-dockerhub.sh
+++ b/ci/cleanup-dockerhub.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# CLEANUP_MODE=sha → delete old SHA tags, keep newest 5
+set -e
+
+: "${DOCKER_USERNAME:?}"
+: "${DOCKER_PASSWORD:?}"
+: "${REPO_PATH:?}"
+
+TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$DOCKER_USERNAME\",\"password\":\"$DOCKER_PASSWORD\"}" \
+  | jq -r .token)
+
+delete_tag() {
+  TAG=$1
+  echo "Deleting tag: $TAG"
+  curl -sf -X DELETE \
+    "https://hub.docker.com/v2/repositories/${REPO_PATH}/tags/${TAG}/" \
+    -H "Authorization: JWT $TOKEN"
+}
+
+TAGS=$(curl -sf \
+  "https://hub.docker.com/v2/repositories/${REPO_PATH}/tags/?page_size=100" \
+  -H "Authorization: JWT $TOKEN" \
+  | jq -r '[.results[] | select(.name | test("^[0-9a-f]{40}$")) | .name] | .[5:] | .[]')
+
+if [ -z "$TAGS" ]; then
+  echo "No old SHA tags to clean up."
+  exit 0
+fi
+
+echo "$TAGS" | while IFS= read -r tag; do
+  delete_tag "$tag"
+done
+
+echo "Cleanup done."

--- a/ci/wait-for-db.py
+++ b/ci/wait-for-db.py
@@ -1,0 +1,23 @@
+import os
+import time
+
+import psycopg2
+
+host = os.environ.get('POSTGRES_HOST', 'localhost')
+port = int(os.environ.get('POSTGRES_PORT', 5432))
+user = os.environ.get('POSTGRES_USER', 'postgres')
+password = os.environ.get('POSTGRES_PASSWORD', '')
+dbname = os.environ.get('POSTGRES_DB', 'postgres')
+
+print(f'Waiting for PostgreSQL at {host}:{port}...')
+while True:
+    try:
+        conn = psycopg2.connect(
+            host=host, port=port, user=user, password=password, dbname=dbname
+        )
+        conn.close()
+        print('PostgreSQL is ready')
+        break
+    except Exception as e:
+        print(f'  Still waiting... ({e})')
+        time.sleep(2)

--- a/ci/wait-for-redis.py
+++ b/ci/wait-for-redis.py
@@ -1,0 +1,18 @@
+import os
+import time
+
+import redis
+
+host = os.environ.get('REDIS_HOST', 'localhost')
+port = int(os.environ.get('REDIS_PORT', 6379))
+
+print(f'Waiting for Redis at {host}:{port}...')
+while True:
+    try:
+        r = redis.Redis(host=host, port=port)
+        r.ping()
+        print('Redis is ready')
+        break
+    except Exception as e:
+        print(f'  Still waiting... ({e})')
+        time.sleep(2)


### PR DESCRIPTION
WHAT:
- 新增 `ci/wait-for-db.py` 及 `ci/wait-for-redis.py` 腳本。
- 在 Drone CI 測試階段前，加入等待資料庫與 Redis 服務的步驟。
- 新增 `ci/cleanup-dockerhub.sh` 腳本，用於清理 Docker Hub 舊標籤。
- 重構 Drone CI 部署流程，加入明確的部署、驗證與標籤清理步驟。
- 為 `kubectl` 指令新增 `|| exit 1` 錯誤處理。

WHY:
- 確保測試在外部服務（DB/Redis）完全就緒後才執行，提高測試可靠性。
- 自動化管理 Docker Hub 上的映像檔標籤，避免累積過多無用標籤。
- 提升部署流程的穩定性與透明度，確保每個階段都能被驗證並處理錯誤。