### PR TITLE
🐛 修正(spotify): 強化 Spotify token 驗證並配置 Sentry 環境

### DIFF
--- a/provider/handlers/spotify.py
+++ b/provider/handlers/spotify.py
@@ -168,11 +168,20 @@ class SpotifyAPIProviderHandler(BaseAPIProviderHandler):
         return tracks
 
     def _is_token_valid(self, access_token: str) -> bool:
+        """
+        透過呼叫需要 playlist-read-private scope 的 endpoint 驗證 token 有效性。
+
+        不使用 /me 的原因：Spotify 對 /me 的授權驗證較寬鬆，用戶在 Spotify 撤銷應用程式
+        授權後，/me 仍可能回傳 200，但存取私人資源（如 private playlist）已是 403。
+        因此改用 GET /me/playlists 作為驗證依據，確保 token 確實具備業務所需的 scope 存取權。
+
+        參考：https://github.com/spotify/web-api/issues/600
+        """
         try:
             SpotifyAPIProviderInterface(
                 provider=self.provider,
                 access_token=access_token,
-            ).get_me()
+            ).get_user_playlists(limit=1)
             return True
         except ProviderException as e:
             if e.status_code in TOKEN_INVALID_STATUS_CODES:

--- a/provider/interfaces/spotify.py
+++ b/provider/interfaces/spotify.py
@@ -94,6 +94,18 @@ class SpotifyAPIProviderInterface(BaseAPIProviderInterface):
         params = {'limit': limit, 'offset': offset}
         return self.handle_request('GET', endpoint, params=params)
 
+    def get_user_playlists(self, limit=1, offset=0):
+        """
+        取得當前授權用戶的歌單列表。
+        用於驗證 access token 是否具備 playlist-read-private scope 的實際存取權，
+        比 /me 更可靠（Spotify 對 /me 的授權驗證較寬鬆，撤銷授權後仍可能回 200）。
+        需要 scope：playlist-read-private
+        :return: dict (Spotify API response)
+        """
+        return self.handle_request(
+            'GET', 'me/playlists', params={'limit': limit, 'offset': offset}
+        )
+
     def get_playlist(self, playlist_id, fields=None):
         """
         取得特定歌單的詳細資訊

--- a/walrus/settings.py
+++ b/walrus/settings.py
@@ -238,4 +238,5 @@ if GLITCHTIP_DSN:
         integrations=[DjangoIntegration(), CeleryIntegration()],
         traces_sample_rate=0.0,
         send_default_pii=False,
+        environment=ENV,
     )


### PR DESCRIPTION
WHAT:
- `provider/handlers/spotify.py`:
 - `_is_token_valid` 方法現在使用 `get_user_playlists` 進行 token 驗證。
 - 新增詳細註解，解釋驗證邏輯變更的原因。
- `provider/interfaces/spotify.py`:
 - 新增 `get_user_playlists` 方法，用於取得用戶歌單列表。
- `walrus/settings.py`:
 - 在 Sentry 初始化時新增 `environment=ENV` 配置。

WHY:
- Spotify 的 `/me` 端點對授權撤銷的驗證較寬鬆，可能在用戶撤銷應用程式權限後仍回傳 200，導致 token 驗證不準確。
- 改用 `get_user_playlists` (需要 `playlist-read-private` 權限) 能更可靠地驗證 token 是否具備業務所需的實際存取權。
- Sentry 環境配置確保錯誤報告能正確區分不同部署環境（如開發、測試、生產）。