### PR TITLE
🐛 修正(provider): 刷新令牌失敗時捕獲ProviderException

### DIFF
--- a/provider/handlers/base.py
+++ b/provider/handlers/base.py
@@ -30,7 +30,10 @@ def with_reauth(fn):
                 raise
 
         self._invalidate_cache()
-        new_token = self.refresh_token()
+        try:
+            new_token = self.refresh_token()
+        except ProviderException:
+            new_token = None
 
         if new_token:
             try:
@@ -228,7 +231,10 @@ class BaseAPIProviderHandler(ABC):
 
         # token 被 provider 拒絕，先清 cache 再嘗試 refresh
         self._invalidate_cache()
-        new_token = self.refresh_token()
+        try:
+            new_token = self.refresh_token()
+        except ProviderException:
+            new_token = None
 
         if new_token and self._is_token_valid(new_token):
             return new_token


### PR DESCRIPTION
將刷新令牌的呼叫包裝在try-except區塊中，以捕獲
ProviderException。

此變更確保當令牌刷新失敗時，
new_token會被設為None，而非拋出未處理的異常。
這提高了令牌刷新機制的穩定性，
並防止因提供者錯誤導致應用程式崩潰。