### PR TITLE
🐛 修正(base.py)：將無效令牌狀態碼從401/403改為僅401

### DIFF
--- a/provider/handlers/base.py
+++ b/provider/handlers/base.py
@@ -8,7 +8,7 @@ from provider.exceptions import ProviderException
 from provider.models import MemberAPIToken, ProviderProxyAccountAPIToken
 from utils.constants import ResponseCode, ResponseMessage
 
-TOKEN_INVALID_STATUS_CODES = {401, 403}
+TOKEN_INVALID_STATUS_CODES = {401}
 
 
 def with_reauth(fn):
@@ -209,12 +209,15 @@ class BaseAPIProviderHandler(ABC):
         if access_token:
             return access_token
 
-        access_token = self.refresh_token()
+        try:
+            access_token = self.refresh_token()
+        except ProviderException:
+            access_token = None
+
         if not access_token:
-            account_type = 'member' if self.member else 'proxy account'
             raise ProviderException(
-                code=ResponseCode.EXTERNAL_API_ACCESS_TOKEN_NOT_FOUND,
-                message=f"Unable to obtain access token for {self.member.email if self.member else self.proxy_account.code} ({account_type})",
+                code=ResponseCode.EXTERNAL_API_REAUTH_REQUIRED,
+                message=ResponseMessage.EXTERNAL_API_REAUTH_REQUIRED,
             )
         return access_token
 

--- a/provider/handlers/spotify.py
+++ b/provider/handlers/spotify.py
@@ -172,19 +172,14 @@ class SpotifyAPIProviderHandler(BaseAPIProviderHandler):
 
     def _is_token_valid(self, access_token: str) -> bool:
         """
-        透過呼叫需要 playlist-read-private scope 的 endpoint 驗證 token 有效性。
-
-        不使用 /me 的原因：Spotify 對 /me 的授權驗證較寬鬆，用戶在 Spotify 撤銷應用程式
-        授權後，/me 仍可能回傳 200，但存取私人資源（如 private playlist）已是 403。
-        因此改用 GET /me/playlists 作為驗證依據，確保 token 確實具備業務所需的 scope 存取權。
-
-        參考：https://github.com/spotify/web-api/issues/600
+        透過呼叫 /me 驗證 token 是否有效。
+        401/403 → return False；5xx / 網路錯誤 → re-raise ProviderException。
         """
         try:
             SpotifyAPIProviderInterface(
                 provider=self.provider,
                 access_token=access_token,
-            ).get_user_playlists(limit=1)
+            ).get_me()
             return True
         except ProviderException as e:
             if e.status_code in TOKEN_INVALID_STATUS_CODES:

--- a/provider/interfaces/spotify.py
+++ b/provider/interfaces/spotify.py
@@ -94,18 +94,6 @@ class SpotifyAPIProviderInterface(BaseAPIProviderInterface):
         params = {'limit': limit, 'offset': offset}
         return self.handle_request('GET', endpoint, params=params)
 
-    def get_user_playlists(self, limit=1, offset=0):
-        """
-        取得當前授權用戶的歌單列表。
-        用於驗證 access token 是否具備 playlist-read-private scope 的實際存取權，
-        比 /me 更可靠（Spotify 對 /me 的授權驗證較寬鬆，撤銷授權後仍可能回 200）。
-        需要 scope：playlist-read-private
-        :return: dict (Spotify API response)
-        """
-        return self.handle_request(
-            'GET', 'me/playlists', params={'limit': limit, 'offset': offset}
-        )
-
     def get_playlist(self, playlist_id, fields=None):
         """
         取得特定歌單的詳細資訊
@@ -128,7 +116,7 @@ class SpotifyAPIProviderInterface(BaseAPIProviderInterface):
         :param market: ISO 3166-1 alpha-2 country code (e.g., 'TW')
         :return: dict (Spotify API response)
         """
-        endpoint = f'playlists/{playlist_id}/tracks'
+        endpoint = f'playlists/{playlist_id}/items'
         params = {'limit': limit, 'offset': offset}
         if market:
             params['market'] = market


### PR DESCRIPTION
🐛 修正(base.py)：處理刷新令牌失敗時的ProviderException
🐛 修正(spotify.py)：將令牌驗證端點從/me/playlists改為/me
🐛 修正(spotify.py)：將取得播放列表曲目的端點從/tracks改為/items
♻️ 重構(spotify.py)：移除未使用的get_user_playlists方法