### PR TITLE
✨ feat(track, config): 讓音軌片段持續時間可配置

### DIFF
--- a/track/models.py
+++ b/track/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 from provider.models import Provider
@@ -68,8 +69,7 @@ class Track(models.Model):
 
     @property
     def clip_end_ms(self):
-        """固定的 clip 結束時間（毫秒）"""
-        return 45000
+        return settings.CLIP_DURATION_MS
 
 
 class TrackAudioFeatures(models.Model):

--- a/walrus/settings.py
+++ b/walrus/settings.py
@@ -229,6 +229,8 @@ CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
 
 SPOTIFY_LISTENING_PROFILE_DAYS = 30
 
+CLIP_DURATION_MS = int(os.environ.get('CLIP_DURATION_MS', 45000))
+
 HERON_BASE_URL = os.environ.get('HERON_BASE_URL')
 
 # GlitchTip / Sentry


### PR DESCRIPTION
WHAT:
- 將 `Track` 模型中的 `clip_end_ms` 屬性從硬編碼值改為 從 `settings.CLIP_DURATION_MS` 讀取。
- 在 `walrus/settings.py` 中新增 `CLIP_DURATION_MS` 設定， 預設為 45000 毫秒，並可透過環境變數覆寫。

WHY:
- 提高靈活性，允許在不修改程式碼的情況下調整音軌片段的持續時間。
- 支援不同的應用場景或測試需求。